### PR TITLE
Configure default role to include edgelambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,32 +44,9 @@ This package uses the `nodejs10.x` Node.js 10 Runtime. Updating the package in y
 
 1. Install the application "standard-redirects-for-cloudfront".
 2. Go to the Cloudformation Console
-3. Select the created role (which brings you to the IAM console)
-4. edit the trust relationship, set the policy to:
-
-```
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "Service": [
-          "lambda.amazonaws.com",
-          "edgelambda.amazonaws.com"
-        ]
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-```
-
-(This allows CloudFront to execute this function as a Lambda@Edge function.)
-
-5. Select the Output Value, this is the ARN (including the version) for the Lambda function.
-6. In CloudFront edit a **Behaviour** and add a **Lambda Function Association** with the *Event Type* "Origin Request" and enter the Lambda function ARN from the previous step.
-7. Wait for the CloudFront distribution to deploy.
+3. Select the Output Value, this is the ARN (including the version) for the Lambda function.
+4. In CloudFront edit a **Behaviour** and add a **Lambda Function Association** with the *Event Type* "Origin Request" and enter the Lambda function ARN from the previous step.
+5. Wait for the CloudFront distribution to deploy.
 
 ### Contact
 

--- a/sam.yaml
+++ b/sam.yaml
@@ -13,6 +13,31 @@ Resources:
       Handler: index.handler
       Runtime: nodejs10.x
       Description: 'Standard Redirects for CloudFront by Digital Sailors via the Serverless Application Repository.'
+      Role: !GetAtt LambdaRole.Arn
       MemorySize: 128
       Timeout: 3
       AutoPublishAlias: 'CurrentProd'
+
+  LambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          Effect: Allow
+          Principal:
+            Service:
+              - lambda.amazonaws.com
+              - edgelambda.amazonaws.com
+          Action: sts:AssumeRole
+      Policies:
+        - PolicyName: edgelambda-policy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: '*'


### PR DESCRIPTION
This patch configures a default lambda role matching what SAM provides
in the default role except it also adds edgelambda in the trusted
relationships so that there is no need to perform an additional
manual step after the fact to include it.

Closes: #3
Signed-off-by: Thanh Ha <zxiiro@gmail.com>